### PR TITLE
Use Gnome Accent Colors to display current events

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Dim Completed Calendar Events",
   "description": "Dim completed events in the top panel menu to easily distinguish between upcoming and past events. You can also highlight events that are ongoing.",
   "uuid": "dim-completed-calendar-events@marcinjahn.com",
-  "shell-version": ["46", "47"],
+  "shell-version": ["47"],
   "url": "https://github.com/marcinjahn/gnome-dim-completed-calendar-events-extension",
   "version": 7
 }

--- a/src/patch/new-reload-events.ts
+++ b/src/patch/new-reload-events.ts
@@ -38,11 +38,11 @@ export function buildPatchedReloadEventsFunction(
         continue;
       }
 
-      const style = styleAsCompleted 
-        ? getCompletedEventStyle() 
-        : styleAsOngoing 
-          ? getOngoingEventStyle() 
-          : null;
+      const style = styleAsCompleted
+        ? getCompletedEventStyle()
+        : styleAsOngoing
+        ? getOngoingEventStyle()
+        : null;
 
       const summaryLabel = new St.Label({
         text: event.summary,
@@ -114,7 +114,7 @@ function getCompletedEventStyle() {
 }
 
 function getOngoingEventStyle() {
-  return "color: #78aeed;"; // Gnome Accent Color
+  return "color: -st-accent-color"; // Gnome Accent Color
 }
 
 interface Event {

--- a/src/patch/new-reload-events.ts
+++ b/src/patch/new-reload-events.ts
@@ -114,7 +114,7 @@ function getCompletedEventStyle() {
 }
 
 function getOngoingEventStyle() {
-  return "color: -st-accent-color"; // Gnome Accent Color
+  return "color: st-lighten(-st-accent-color, 15%)"; // Gnome Accent Color
 }
 
 interface Event {


### PR DESCRIPTION
Quick, small fix for something that bugged me after upgrading to GNOME 47. :smile: 

This replaces the color `#78aeed` defined in `src/patch/new-reload-events.ts` with the CSS property `-st-accent-color` to get the correct accent color, as that can now be configured by the user in the gnome settings.

I have checked that this also results in the accent color being updated if the setting is changed while the extension is loaded.