### PR TITLE
Add GNOME 48 support to metadata

### DIFF
--- a/resources/metadata.json
+++ b/resources/metadata.json
@@ -2,7 +2,7 @@
   "name": "Dim Completed Calendar Events",
   "description": "Dim completed events in the top panel menu to easily distinguish between upcoming and past events. You can also highlight events that are ongoing.",
   "uuid": "dim-completed-calendar-events@marcinjahn.com",
-  "shell-version": ["47"],
+  "shell-version": ["47", "48"],
   "url": "https://github.com/marcinjahn/gnome-dim-completed-calendar-events-extension",
   "version": 9
 }


### PR DESCRIPTION
Tested with GNOME 48: ![dim-completed-calendar-events-on-gnome-48](https://github.com/user-attachments/assets/02face5d-bd1b-47ee-bcf6-ad5cfd49db39)

Gnome shells Looking Glass shows no errors for this extension (sorry I'm unable to screenshot that).

Resolves: #7 